### PR TITLE
add admin user creation job and bump netmaker version to v0.23.0

### DIFF
--- a/.github/workflows/ci-helm-lint-test.yml
+++ b/.github/workflows/ci-helm-lint-test.yml
@@ -49,4 +49,4 @@ jobs:
         id: install
         if: steps.list-changed.outputs.changed == 'true'
         run: |
-            ct install --target-branch ${{ github.event.repository.default_branch }}
+            ct install --target-branch ${{ github.event.repository.default_branch }} --helm-extra-set-args "--set=netmaker.admin.user=testadmin" --helm-extra-set-args "--set=netmaker.admin.password=testadminpassword"

--- a/charts/netmaker/Chart.yaml
+++ b/charts/netmaker/Chart.yaml
@@ -15,13 +15,13 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.10.1
+version: 0.11.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "v0.21.2"
+appVersion: "v0.23.0"
 
 maintainers:
   - name: "jessebot"

--- a/charts/netmaker/README.md
+++ b/charts/netmaker/README.md
@@ -61,7 +61,7 @@ A Helm chart to run HA Netmaker on Kubernetes
 | mq.tolerations | object | `{}` | optional tolerations settings for mqtt |
 | mq.username | string | `"netmaker"` |  |
 | nameOverride | string | `""` | override the name for netmaker objects |
-| netmaker.admin.existingSecret | string | `""` | set admin user/password via an existing k8s secret. If set, disables registration via UI, and ignores netmaker.admin.user, netmaker.admin.password |
+| netmaker.admin.existingSecret | string | `""` | set admin user/password via an existing k8s secret. Must have keys: ADMIN_USER, ADMIN_PASSWORD  If set, disables registration via UI, and ignores netmaker.admin.user, netmaker.admin.password |
 | netmaker.admin.password | string | `""` | initial admin user's password, ignored if netmaker.admin.existingSecret set |
 | netmaker.admin.user | string | `""` | initial admin user to create. if set, disables registration via UI. Ignored if netmaker.admin.existingSecret set |
 | netmaker.enterprise | object | `{"licenseKey":"","tenantId":""}` | if using enterprise edition fill out this section |

--- a/charts/netmaker/README.md
+++ b/charts/netmaker/README.md
@@ -61,7 +61,7 @@ A Helm chart to run HA Netmaker on Kubernetes
 | mq.tolerations | object | `{}` | optional tolerations settings for mqtt |
 | mq.username | string | `"netmaker"` |  |
 | nameOverride | string | `""` | override the name for netmaker objects |
-| netmaker.admin.existingSecret | string | `""` | set admin user/password via an existing k8s secret. Must have keys: ADMIN_USER, ADMIN_PASSWORD  If set, disables registration via UI, and ignores netmaker.admin.user, netmaker.admin.password |
+| netmaker.admin.existingSecret | string | `""` | set admin user/password via an existing k8s secret. Must have keys: ADMIN_USER, ADMIN_PASSWORD If set, disables registration via UI, and ignores netmaker.admin.user, netmaker.admin.password |
 | netmaker.admin.password | string | `""` | initial admin user's password, ignored if netmaker.admin.existingSecret set |
 | netmaker.admin.user | string | `""` | initial admin user to create. if set, disables registration via UI. Ignored if netmaker.admin.existingSecret set |
 | netmaker.enterprise | object | `{"licenseKey":"","tenantId":""}` | if using enterprise edition fill out this section |

--- a/charts/netmaker/README.md
+++ b/charts/netmaker/README.md
@@ -62,8 +62,8 @@ A Helm chart to run HA Netmaker on Kubernetes
 | mq.username | string | `"netmaker"` |  |
 | nameOverride | string | `""` | override the name for netmaker objects |
 | netmaker.admin.existingSecret | string | `""` | set admin user/password via an existing k8s secret. If set, disables registration via UI, and ignores netmaker.admin.user, netmaker.admin.password |
-| netmaker.admin.password | string | `""` | initial admin user's password, ignored if existingSecret set |
-| netmaker.admin.user | string | `""` | initial admin user to create. if set disables registration via UI. ignored if existingSecret set |
+| netmaker.admin.password | string | `""` | initial admin user's password, ignored if netmaker.admin.existingSecret set |
+| netmaker.admin.user | string | `""` | initial admin user to create. if set, disables registration via UI. Ignored if netmaker.admin.existingSecret set |
 | netmaker.enterprise | object | `{"licenseKey":"","tenantId":""}` | if using enterprise edition fill out this section |
 | netmaker.enterprise.licenseKey | string | `""` | netmaker enterprise license key, ignored if netmaker.existingSecret set |
 | netmaker.enterprise.tenantId | string | `""` | netmaker enterprise tenant ID, ignored if netmaker.existingSecret set |

--- a/charts/netmaker/README.md
+++ b/charts/netmaker/README.md
@@ -1,6 +1,6 @@
 # netmaker
 
-![Version: 0.10.1](https://img.shields.io/badge/Version-0.10.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v0.21.2](https://img.shields.io/badge/AppVersion-v0.21.2-informational?style=flat-square)
+![Version: 0.11.0](https://img.shields.io/badge/Version-0.11.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v0.23.0](https://img.shields.io/badge/AppVersion-v0.23.0-informational?style=flat-square)
 
 A Helm chart to run HA Netmaker on Kubernetes
 
@@ -61,6 +61,9 @@ A Helm chart to run HA Netmaker on Kubernetes
 | mq.tolerations | object | `{}` | optional tolerations settings for mqtt |
 | mq.username | string | `"netmaker"` |  |
 | nameOverride | string | `""` | override the name for netmaker objects |
+| netmaker.admin.existingSecret | string | `""` | set admin user/password via an existing k8s secret. If set, disables registration via UI, and ignores netmaker.admin.user, netmaker.admin.password |
+| netmaker.admin.password | string | `""` | initial admin user's password, ignored if existingSecret set |
+| netmaker.admin.user | string | `""` | initial admin user to create. if set disables registration via UI. ignored if existingSecret set |
 | netmaker.enterprise | object | `{"licenseKey":"","tenantId":""}` | if using enterprise edition fill out this section |
 | netmaker.enterprise.licenseKey | string | `""` | netmaker enterprise license key, ignored if netmaker.existingSecret set |
 | netmaker.enterprise.tenantId | string | `""` | netmaker enterprise tenant ID, ignored if netmaker.existingSecret set |

--- a/charts/netmaker/templates/_helpers.tpl
+++ b/charts/netmaker/templates/_helpers.tpl
@@ -170,6 +170,17 @@ netmaker-secret
 {{- end }}
 
 {{/*
+netmaker admin credentials secret
+*/}}
+{{- define "netmaker.admin.secret" -}}
+{{- if .Values.netmaker.admin.existingSecret -}}
+{{ .Values.netmaker.admin.existingSecret }}
+{{- else -}}
+netmaker-admin-secret
+{{- end }}
+{{- end }}
+
+{{/*
 mqtt (broker) secret
 */}}
 {{- define "netmaker.mq.secret" -}}

--- a/charts/netmaker/templates/netmaker-admin-secret.yaml
+++ b/charts/netmaker/templates/netmaker-admin-secret.yaml
@@ -1,0 +1,13 @@
+{{- if and .Values.netmaker.admin.user (not .Values.netmaker.admin.existingSecret) }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: netmaker-admin-secret
+  labels:
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+type: Opaque
+data:
+  ADMIN_USER: {{ .Values.netmaker.admin.user | b64enc | quote }}
+  ADMIN_PASSWORD: {{ .Values.netmaker.admin.password | b64enc | quote }}
+{{- end }}

--- a/charts/netmaker/templates/netmaker-admin-user-job.yaml
+++ b/charts/netmaker/templates/netmaker-admin-user-job.yaml
@@ -19,7 +19,7 @@ spec:
             - |-
               curl --location "https://$SERVER_HTTP_HOST/api/users/adm/createsuperadmin" \ 
                    --header 'Content-Type: application/json' \
-                   --data "{'username':'$ADMIN_USER', 'password':'$ADMIN_PASSWORD'}"
+                   --data "{\"username\":\"$ADMIN_USER\",\"password\":\"$ADMIN_PASSWORD\"}"
           env:
             - name: SERVER_HTTP_HOST
               valueFrom:

--- a/charts/netmaker/templates/netmaker-admin-user-job.yaml
+++ b/charts/netmaker/templates/netmaker-admin-user-job.yaml
@@ -1,0 +1,36 @@
+{{- if or .Values.netmaker.admin.user .Values.netmaker.admin.existingSecret }}
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: setup-initial-user-job
+spec:
+  template:
+    metadata:
+      name: setup-initial-user-pod
+    spec:
+      containers:
+        - name: setup-initial-user
+          image: curlimages/curl:latest
+          command:
+            - |-
+              curl --location "https://$SERVER_HTTP_HOST/api/users/adm/createsuperadmin" \ 
+                   --header 'Content-Type: application/json' \
+                   --data "{'username':'$ADMIN_USER', 'password':'$ADMIN_PASSWORD'}"
+          env:
+            - name: SERVER_HTTP_HOST
+              valueFrom:
+                secretKeyRef:
+                  key: SERVER_HTTP_HOST
+                  name: {{ include "netmaker.secret" . }}
+            - name: ADMIN_USER
+              valueFrom:
+                secretKeyRef:
+                  key: ADMIN_USER
+                  name: {{ include "netmaker.admin.secret" . }}
+            - name: ADMIN_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  key: ADMIN_PASSWORD
+                  name: {{ include "netmaker.admin.secret" . }}
+{{- end }}

--- a/charts/netmaker/templates/netmaker-admin-user-job.yaml
+++ b/charts/netmaker/templates/netmaker-admin-user-job.yaml
@@ -4,6 +4,9 @@ apiVersion: batch/v1
 kind: Job
 metadata:
   name: setup-initial-user-job
+  annotations:
+    "helm.sh/hook": post-install
+    "helm.sh/hook-delete-policy": hook-succeeded
 spec:
   template:
     metadata:

--- a/charts/netmaker/values.yaml
+++ b/charts/netmaker/values.yaml
@@ -64,8 +64,9 @@ netmaker:
     user: ""
     # -- initial admin user's password, ignored if netmaker.admin.existingSecret set
     password: ""
-    # -- set admin user/password via an existing k8s secret. If set, disables
-    # registration via UI, and ignores netmaker.admin.user, netmaker.admin.password
+    # -- set admin user/password via an existing k8s secret. Must have keys:
+    # ADMIN_USER, ADMIN_PASSWORD 
+    # If set, disables registration via UI, and ignores netmaker.admin.user, netmaker.admin.password
     existingSecret: ""
 
   # -- if using enterprise edition fill out this section

--- a/charts/netmaker/values.yaml
+++ b/charts/netmaker/values.yaml
@@ -58,6 +58,15 @@ netmaker:
   # -- Auto disable a user's connecteds clients bassed on JWT token expiration
   racAutoDisable: "true"
 
+  admin:
+    # -- initial admin user to create. if set disables registration via UI. ignored if existingSecret set
+    user: ""
+    # -- initial admin user's password, ignored if existingSecret set
+    password: ""
+    # -- set admin user/password via an existing k8s secret. If set, disables registration via UI,
+    # and ignores netmaker.admin.user, netmaker.admin.password
+    existingSecret: ""
+
   # -- if using enterprise edition fill out this section
   enterprise:
     # -- netmaker enterprise license key, ignored if netmaker.existingSecret set

--- a/charts/netmaker/values.yaml
+++ b/charts/netmaker/values.yaml
@@ -65,7 +65,7 @@ netmaker:
     # -- initial admin user's password, ignored if netmaker.admin.existingSecret set
     password: ""
     # -- set admin user/password via an existing k8s secret. Must have keys:
-    # ADMIN_USER, ADMIN_PASSWORD 
+    # ADMIN_USER, ADMIN_PASSWORD
     # If set, disables registration via UI, and ignores netmaker.admin.user, netmaker.admin.password
     existingSecret: ""
 

--- a/charts/netmaker/values.yaml
+++ b/charts/netmaker/values.yaml
@@ -59,12 +59,13 @@ netmaker:
   racAutoDisable: "true"
 
   admin:
-    # -- initial admin user to create. if set disables registration via UI. ignored if existingSecret set
+    # -- initial admin user to create. if set, disables registration via UI.
+    # Ignored if netmaker.admin.existingSecret set
     user: ""
-    # -- initial admin user's password, ignored if existingSecret set
+    # -- initial admin user's password, ignored if netmaker.admin.existingSecret set
     password: ""
-    # -- set admin user/password via an existing k8s secret. If set, disables registration via UI,
-    # and ignores netmaker.admin.user, netmaker.admin.password
+    # -- set admin user/password via an existing k8s secret. If set, disables
+    # registration via UI, and ignores netmaker.admin.user, netmaker.admin.password
     existingSecret: ""
 
   # -- if using enterprise edition fill out this section


### PR DESCRIPTION
- Bumps appVersion to [v0.23.0](https://github.com/gravitl/netmaker/releases/tag/v0.23.0).
- Adds new `netmaker.admin`, so users can set an initial super admin user via helm post-install hook job. The new values are as following:

```yaml
netmaker:
  admin:
    # -- initial admin user to create. if set, disables registration via UI.
    # Ignored if netmaker.admin.existingSecret set
    user: ""
    # -- initial admin user's password, ignored if netmaker.admin.existingSecret set
    password: ""
    # -- set admin user/password via an existing k8s secret. If set, disables
    # registration via UI, and ignores netmaker.admin.user, netmaker.admin.password
    existingSecret: ""
```