### PR TITLE
add restart policy for user creation job

### DIFF
--- a/charts/netmaker/Chart.yaml
+++ b/charts/netmaker/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.11.0
+version: 0.11.1
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/netmaker/README.md
+++ b/charts/netmaker/README.md
@@ -1,6 +1,6 @@
 # netmaker
 
-![Version: 0.11.0](https://img.shields.io/badge/Version-0.11.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v0.23.0](https://img.shields.io/badge/AppVersion-v0.23.0-informational?style=flat-square)
+![Version: 0.11.1](https://img.shields.io/badge/Version-0.11.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v0.23.0](https://img.shields.io/badge/AppVersion-v0.23.0-informational?style=flat-square)
 
 A Helm chart to run HA Netmaker on Kubernetes
 
@@ -62,6 +62,7 @@ A Helm chart to run HA Netmaker on Kubernetes
 | mq.username | string | `"netmaker"` |  |
 | nameOverride | string | `""` | override the name for netmaker objects |
 | netmaker.admin.existingSecret | string | `""` | set admin user/password via an existing k8s secret. Must have keys: ADMIN_USER, ADMIN_PASSWORD If set, disables registration via UI, and ignores netmaker.admin.user, netmaker.admin.password |
+| netmaker.admin.jobRestartPolicy | string | `"Never"` | restart policy for the admin user creation job |
 | netmaker.admin.password | string | `""` | initial admin user's password, ignored if netmaker.admin.existingSecret set |
 | netmaker.admin.user | string | `""` | initial admin user to create. if set, disables registration via UI. Ignored if netmaker.admin.existingSecret set |
 | netmaker.enterprise | object | `{"licenseKey":"","tenantId":""}` | if using enterprise edition fill out this section |

--- a/charts/netmaker/templates/netmaker-admin-user-job.yaml
+++ b/charts/netmaker/templates/netmaker-admin-user-job.yaml
@@ -12,6 +12,7 @@ spec:
     metadata:
       name: setup-initial-user-pod
     spec:
+      restartPolicy: {{ .Values.netmaker.admin.jobRestartPolicy }}
       containers:
         - name: setup-initial-user
           image: curlimages/curl:latest

--- a/charts/netmaker/values.yaml
+++ b/charts/netmaker/values.yaml
@@ -68,6 +68,8 @@ netmaker:
     # ADMIN_USER, ADMIN_PASSWORD
     # If set, disables registration via UI, and ignores netmaker.admin.user, netmaker.admin.password
     existingSecret: ""
+    # -- restart policy for the admin user creation job
+    jobRestartPolicy: "Never"
 
   # -- if using enterprise edition fill out this section
   enterprise:


### PR DESCRIPTION
Adds new option for the user creation job restart policy (defaults to Never):

```yaml
netmaker:
  admin:
    # restart policy for the admin user creation job
    jobRestartPolicy: "Never"
```