### PR TITLE
fix: get admin user creation job's env vars from configmapRef

### DIFF
--- a/charts/netmaker/Chart.yaml
+++ b/charts/netmaker/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.11.1
+version: 0.11.2
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/netmaker/README.md
+++ b/charts/netmaker/README.md
@@ -1,6 +1,6 @@
 # netmaker
 
-![Version: 0.11.1](https://img.shields.io/badge/Version-0.11.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v0.23.0](https://img.shields.io/badge/AppVersion-v0.23.0-informational?style=flat-square)
+![Version: 0.11.2](https://img.shields.io/badge/Version-0.11.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v0.23.0](https://img.shields.io/badge/AppVersion-v0.23.0-informational?style=flat-square)
 
 A Helm chart to run HA Netmaker on Kubernetes
 

--- a/charts/netmaker/templates/netmaker-admin-user-job.yaml
+++ b/charts/netmaker/templates/netmaker-admin-user-job.yaml
@@ -24,9 +24,9 @@ spec:
           env:
             - name: SERVER_HTTP_HOST
               valueFrom:
-                secretKeyRef:
+                configMapKeyRef:
                   key: SERVER_HTTP_HOST
-                  name: {{ include "netmaker.secret" . }}
+                  name: {{ include "netmaker.fullname" . }}-env
             - name: ADMIN_USER
               valueFrom:
                 secretKeyRef:


### PR DESCRIPTION
Previously, we were trying to get the `$SERVER_HTTP_HOST` from the netmaker-secret. Now we get it from the netmaker.fullname-env configmap.